### PR TITLE
Fix library order for newer GCC linking behavior

### DIFF
--- a/src/Makefile.linux
+++ b/src/Makefile.linux
@@ -1,10 +1,11 @@
 CFLAGS=-Wall -pedantic -g -DUSCSI_LINUX_SCSI -DSCSI -DNO_STRLCPY -I/usr/pkg/include
-LDFLAGS=-lgc # -lbsd
+LD_PREFIX_FLAGS=#-lbsd
+LD_SUFFIX_FLAGS=-lgc
 
 all : mamtool
 
 mamtool : endian_utils.o mamtool.o uscsi_subr.o uscsi_sense.o
-	$(CC) $(LDFLAGS) -o $@ endian_utils.o uscsi_sense.o mamtool.o uscsi_subr.o
+	$(CC) $(LD_PREFIX_FLAGS) -o $@ endian_utils.o uscsi_sense.o mamtool.o uscsi_subr.o $(LD_SUFFIX_FLAGS)
 
 %.o : %.c *.h
 	$(CC) $(CFLAGS) -c $<


### PR DESCRIPTION
Trying to build mamtool on Debian 12 fails to build with undefined references to libgc like so:

```
cc -Wall -pedantic -g -DUSCSI_LINUX_SCSI -DSCSI -DNO_STRLCPY -I/usr/pkg/include -c endian_utils.c
cc -Wall -pedantic -g -DUSCSI_LINUX_SCSI -DSCSI -DNO_STRLCPY -I/usr/pkg/include -c mamtool.c
cc -Wall -pedantic -g -DUSCSI_LINUX_SCSI -DSCSI -DNO_STRLCPY -I/usr/pkg/include -c uscsi_subr.c
cc -Wall -pedantic -g -DUSCSI_LINUX_SCSI -DSCSI -DNO_STRLCPY -I/usr/pkg/include -c uscsi_sense.c
cc -lgc  -o mamtool endian_utils.o uscsi_sense.o mamtool.o uscsi_subr.o
/usr/bin/ld: mamtool.o: in function `attribute_set_value':
/tmp/mamtool/src/mamtool.c:222: undefined reference to `GC_malloc'
/usr/bin/ld: mamtool.o: in function `attribute_value_to_string':
/tmp/mamtool/src/mamtool.c:243: undefined reference to `GC_malloc'
/usr/bin/ld: mamtool.o: in function `mam_write_attribute_1':
/tmp/mamtool/src/mamtool.c:419: undefined reference to `GC_malloc'
/usr/bin/ld: mamtool.o: in function `mam_read_attribute_1':
/tmp/mamtool/src/mamtool.c:442: undefined reference to `GC_malloc'
/usr/bin/ld: /tmp/mamtool/src/mamtool.c:453: undefined reference to `GC_malloc'
/usr/bin/ld: mamtool.o:/tmp/mamtool/src/mamtool.c:485: more undefined references to `GC_malloc' follow
/usr/bin/ld: mamtool.o: in function `main':
/tmp/mamtool/src/mamtool.c:714: undefined reference to `GC_init'
/usr/bin/ld: /tmp/mamtool/src/mamtool.c:719: undefined reference to `GC_strdup'
/usr/bin/ld: /tmp/mamtool/src/mamtool.c:722: undefined reference to `GC_strdup'
/usr/bin/ld: /tmp/mamtool/src/mamtool.c:735: undefined reference to `GC_strdup'
```

It seems that with newer versions of GCC, libraries are only linked as needed. Moving the `-lgc` flag to the end of the `ld` command fixes this build issue.

I broke the `LDFLAGS` into prefix and suffix flags in case flags are still wanted in that position.

----------------------------

I'm not really a C developer, so please correct me if there's a better way to do this 😅